### PR TITLE
Switch to Debian Sid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:sid-slim
 
 RUN apt-get update && apt -y --no-install-recommends install mame-tools
 


### PR DESCRIPTION
Debian Bullseye latest version of MAME is 0.228. On Sid, it's 0.251 and will likely continue to get updated, making the occasional update easier. Switching to Sid shouldn't do anything to stability, and it includes the latest bugfixes to chdman including [this bug about files with dollar signs in them](https://github.com/mamedev/mame/issues/9822). I have tested both versions locally and the old Bullseye image fails to compress a BIN/CUE with dollar signs in the name while the version on Sid completes successfully.